### PR TITLE
Update uve-api.yaml

### DIFF
--- a/uve-api.yaml
+++ b/uve-api.yaml
@@ -54,9 +54,9 @@ paths:
           application/cbor+base45:
             schema:
               $ref: '#/components/schemas/CertificateEncoded'
-          application/cbor:
-            schema:
-              $ref: '#/components/schemas/CertificateBinary'
+#          application/cbor:
+#            schema:
+#              $ref: '#/components/schemas/CertificateBinary'
 #          application/pdf:
 #            schema:
 #              $ref: '#/components/schemas/CertificationPDF'
@@ -93,14 +93,14 @@ components:
       format: base45
       example: "HC1:6BFOXN*TS0BI$ZD4N9:9S6RCVN5+O30K3/XIV0W23NTDEMWK4MI6UOS03CR83KLBKAVN74.CL91/8K6%KEG3983NS9SVBHABVCNN95SWMPHQUHQN%A400H%UBT16Y51Y9AT1:+P6YBKD0:XB7NGJQOIS7I$H%T5+XO8YJMVHBZJF 9NSG:PICIG%*47%S%*48YIZ73423ZQT-EJDG3XW44$22CLY.IE.KD+2H0D3ZCU7JI$2K3JQH5-Y3$PA$HSCHBI I7995R5ZFQETU 9R*PP:+P*.1D9RYO05QD/8D3FC:XIBEIVG395EP1E+WEDJL8FF3DE0OA0D9E2LBHHNHL$EQ+-CVYCMBB:AV5AL5:4A93MOJLWT.C3FDA.-B97U: KMZNKASADIMKN2GFLF9$HF.3O.X21FDLW4L4OVIOE1M24OR:FTNP8EFVMP9/HWKP/HLIJL8JF8JF172OTTHO9YW2E6LS7WGYNDDSHRSFXT*LMK8P*G8QWD8%P%5GPPMEVMTHDBESW2L.TN8BBBDR9+JLDR/1JGIF8BS0IKT8LB1T7WLA:FI%JI50H:EK1"
 
-    CertificateBinary:
-      description: >-
-        Binary representation of the Digital Corona Certificate (DCC) according to EU specification.
-        This is a pure CBOR Web Token (CWT) without compression and encoding and HC1: prefix.
-      type: string
-      format: binary
-      example: "<CBOR Web Token>"
-
+#    CertificateBinary:
+#      description: >-
+#        Binary representation of the Digital Corona Certificate (DCC) according to EU specification.
+#        This is a pure CBOR Web Token (CWT) without compression and encoding and HC1: prefix.
+#      type: string
+#      format: binary
+#      example: "<CBOR Web Token>"
+#
 #    CertificationPDF:
 #      description: >-
 #        A rendered PDF document containing the certificate information including a

--- a/uve-api.yaml
+++ b/uve-api.yaml
@@ -83,7 +83,7 @@ paths:
 components:
   schemas:
     DigicalCovidCertificate:
-      '$ref': 'schema/DCC.combined-schema.json'
+      '$ref': 'https://github.com/ehn-dcc-development/ehn-dcc-schema/DCC.combined-schema.json'
 
     CertificateEncoded:
       description: >-

--- a/uve-api.yaml
+++ b/uve-api.yaml
@@ -54,12 +54,6 @@ paths:
           application/cbor+base45:
             schema:
               $ref: '#/components/schemas/CertificateEncoded'
-#          application/cbor:
-#            schema:
-#              $ref: '#/components/schemas/CertificateBinary'
-#          application/pdf:
-#            schema:
-#              $ref: '#/components/schemas/CertificationPDF'
       responses:
         '200':
           description: Certificate is authentic.
@@ -69,21 +63,17 @@ paths:
                 $ref: '#/components/schemas/DigicalCovidCertificate'
         '400':
           description: Invalid certificate
-#        '401':
-#          description: Authentication Failure (Credential missing)
         '403':
           description: Forbidden (Invalid Credentials)
         '406':
           description: Incorrect data model
         '500':
           description: Internal Server Error
-#      security:
-#        - AppBearerToken: [ ]
 
 components:
   schemas:
     DigicalCovidCertificate:
-      '$ref': 'https://github.com/ehn-dcc-development/ehn-dcc-schema/DCC.combined-schema.json'
+      '$ref': 'schema/DCC.combined-schema.json'
 
     CertificateEncoded:
       description: >-
@@ -92,27 +82,4 @@ components:
       type: string
       format: base45
       example: "HC1:6BFOXN*TS0BI$ZD4N9:9S6RCVN5+O30K3/XIV0W23NTDEMWK4MI6UOS03CR83KLBKAVN74.CL91/8K6%KEG3983NS9SVBHABVCNN95SWMPHQUHQN%A400H%UBT16Y51Y9AT1:+P6YBKD0:XB7NGJQOIS7I$H%T5+XO8YJMVHBZJF 9NSG:PICIG%*47%S%*48YIZ73423ZQT-EJDG3XW44$22CLY.IE.KD+2H0D3ZCU7JI$2K3JQH5-Y3$PA$HSCHBI I7995R5ZFQETU 9R*PP:+P*.1D9RYO05QD/8D3FC:XIBEIVG395EP1E+WEDJL8FF3DE0OA0D9E2LBHHNHL$EQ+-CVYCMBB:AV5AL5:4A93MOJLWT.C3FDA.-B97U: KMZNKASADIMKN2GFLF9$HF.3O.X21FDLW4L4OVIOE1M24OR:FTNP8EFVMP9/HWKP/HLIJL8JF8JF172OTTHO9YW2E6LS7WGYNDDSHRSFXT*LMK8P*G8QWD8%P%5GPPMEVMTHDBESW2L.TN8BBBDR9+JLDR/1JGIF8BS0IKT8LB1T7WLA:FI%JI50H:EK1"
-
-#    CertificateBinary:
-#      description: >-
-#        Binary representation of the Digital Corona Certificate (DCC) according to EU specification.
-#        This is a pure CBOR Web Token (CWT) without compression and encoding and HC1: prefix.
-#      type: string
-#      format: binary
-#      example: "<CBOR Web Token>"
-#
-#    CertificationPDF:
-#      description: >-
-#        A rendered PDF document containing the certificate information including a
-#        Digital Green Certificate (DGC) QR Code according to EU specification.
-#      type: string
-#      format: binary
-#      example: "<PDF>"
-#
-#  securitySchemes:
-#    AppBearerToken:
-#      type: http
-#      description: >-
-#        Authentication is based on a bearer token
-#      scheme: bearer
-#      bearerFormat: JWT
+      

--- a/uve-api.yaml
+++ b/uve-api.yaml
@@ -41,11 +41,11 @@ paths:
     post:
       tags:
         - Verification
-      summary: Verify a certificate for validity.
+      summary: Verify a certificate for authenticity.
       description: |
         # Description
 
-        Checks the signature and verifies the validity of a
+        Checks the signature and verifies the authenticity of a
         [Digital Covid Certificate (DCC)](https://github.com/ehn-digital-green-development/ehn-dgc-schema/).
       requestBody:
         description: >-
@@ -62,23 +62,23 @@ paths:
 #              $ref: '#/components/schemas/CertificationPDF'
       responses:
         '200':
-          description: Certificate is valid.
+          description: Certificate is authentic.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DigicalCovidCertificate'
         '400':
           description: Invalid certificate
-        '401':
-          description: Authentication Failure (Credential missing)
+#        '401':
+#          description: Authentication Failure (Credential missing)
         '403':
           description: Forbidden (Invalid Credentials)
         '406':
           description: Incorrect data model
         '500':
           description: Internal Server Error
-      security:
-        - AppBearerToken: [ ]
+#      security:
+#        - AppBearerToken: [ ]
 
 components:
   schemas:
@@ -87,7 +87,7 @@ components:
 
     CertificateEncoded:
       description: >-
-        Base45 encoded and compressed Digital Green Certificate (DGC) according to EU specification. An encoded
+        Base45 encoded and compressed Digital Corona Certificate (DCC) according to EU specification. An encoded
         certificate can be directly rendered as a QR code according to the EU specification.
       type: string
       format: base45
@@ -95,24 +95,24 @@ components:
 
     CertificateBinary:
       description: >-
-        Binary representation of the Digital Green Certificate (DGC) according to EU specification.
+        Binary representation of the Digital Corona Certificate (DCC) according to EU specification.
         This is a pure CBOR Web Token (CWT) without compression and encoding and HC1: prefix.
       type: string
       format: binary
       example: "<CBOR Web Token>"
 
-    CertificationPDF:
-      description: >-
-        A rendered PDF document containing the certificate information including a
-        Digital Green Certificate (DGC) QR Code according to EU specification.
-      type: string
-      format: binary
-      example: "<PDF>"
-
-  securitySchemes:
-    AppBearerToken:
-      type: http
-      description: >-
-        Authentication is based on a bearer token
-      scheme: bearer
-      bearerFormat: JWT
+#    CertificationPDF:
+#      description: >-
+#        A rendered PDF document containing the certificate information including a
+#        Digital Green Certificate (DGC) QR Code according to EU specification.
+#      type: string
+#      format: binary
+#      example: "<PDF>"
+#
+#  securitySchemes:
+#    AppBearerToken:
+#      type: http
+#      description: >-
+#        Authentication is based on a bearer token
+#      scheme: bearer
+#      bearerFormat: JWT


### PR DESCRIPTION
changed "valid" to "authentic" in order to allow for validation services above the verification services
dropped the PDF schema
dropped the authenicatiopn JWT Token